### PR TITLE
Fix fsm_mysql service to use defined volumes

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       MYSQL_ROOT_PASSWORD: 123456
       TZ: Asia/Shanghai
     volumes:
-      - fba_mysql:/var/lib/mysql
+      - fsm_mysql:/var/lib/mysql
     networks:
       - fsm_network
     command:


### PR DESCRIPTION
I encountered an issue when building the Docker container, where the fsm_mysql service refers to an undefined volume, resulting in the following error:
`service "fsm_mysql" refers to undefined volume fba_mysql: invalid compose project`

I suspect this might be a simple typographical error. This pull request addresses and fixes the issue.